### PR TITLE
std.math.log: use fyl2x asm instruction if available

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -2552,17 +2552,12 @@ unittest
  *    $(TR $(TD +$(INFIN))    $(TD +$(INFIN)) $(TD no)           $(TD no))
  *    )
  */
-version(LDC)
-{
-    real log(real x) @safe pure nothrow @nogc { return llvm_log(x); }
-}
-else
-{
-
 real log(real x) @safe pure nothrow @nogc
 {
     version (INLINE_YL2X)
         return yl2x(x, LN2);
+    else version(LDC)
+        return llvm_log(x);
     else
     {
         // Coefficients for log(1 + x)


### PR DESCRIPTION
This improve performance of std.math.log.
