### PR TITLE
Experimental: Don't reverse parameter order for extern(D) on x86_64.

### DIFF
--- a/std/internal/digest/sha_SSSE3.d
+++ b/std/internal/digest/sha_SSSE3.d
@@ -586,8 +586,8 @@ version(USE_SSSE3)
         {
             /*
              * Parameters:
-             *   RSI contains pointer to state
-             *   RDI contains pointer to input buffer
+             *   RDI (Win64: RCX) contains pointer to state
+             *   RSI (Win64: RDX) contains pointer to input buffer
              *
              * Stack layout as follows:
              * +----------------+
@@ -603,15 +603,30 @@ version(USE_SSSE3)
              * | Wi+Ki          | <- RSP
              * +----------------+ <- 16byte aligned
              */
-            return [// Save registers according to calling convention
-                    "push RBP",
-                    "push RBX",
-                    // Save parameters
-                    "mov "~STATE_PTR~", RSI", //pointer to state
-                    "mov "~BUFFER_PTR~", RDI", //pointer to buffer
-                    // Align stack
-                    "sub RSP, 4*16+8",
-            ];
+            version(Win64)
+            {
+                return [// Save registers according to calling convention
+                        "push RBP",
+                        "push RBX",
+                        // Save parameters
+                        "mov "~STATE_PTR~", RCX", //pointer to state
+                        "mov "~BUFFER_PTR~", RDX", //pointer to buffer
+                        // Align stack
+                        "sub RSP, 4*16+8",
+                ];
+            }
+            else
+            {
+                return [// Save registers according to calling convention
+                        "push RBP",
+                        "push RBX",
+                        // Save parameters
+                        "mov "~STATE_PTR~", RDI", //pointer to state
+                        "mov "~BUFFER_PTR~", RSI", //pointer to buffer
+                        // Align stack
+                        "sub RSP, 4*16+8",
+                ];
+            }
         }
     }
 

--- a/std/math.d
+++ b/std/math.d
@@ -1168,8 +1168,8 @@ real atan2(real y, real x) @trusted pure nothrow @nogc
         {
             asm pure nothrow @nogc {
                 naked;
-                fld real ptr [RDX]; // y
-                fld real ptr [RCX]; // x
+                fld real ptr [RCX]; // y
+                fld real ptr [RDX]; // x
                 fpatan;
                 ret;
             }
@@ -2381,12 +2381,16 @@ version (none) {
     {
         version (Win64)
         {
+            // RCX: pointer to creal result
+            // RDX: pointer to y
             asm pure nothrow @nogc
             {
                 naked;
-                fld     real ptr [ECX];
+                fld     real ptr [RDX]; // y
                 fsincos;
                 fxch    ST(1), ST(0);
+                fstp    real ptr [RCX];
+                fstp    real ptr 16[RCX];
                 ret;
             }
         }
@@ -3582,9 +3586,9 @@ real scalbn(real x, int n) @trusted nothrow @nogc
         {
             asm pure nothrow @nogc {
                 naked                           ;
-                mov     16[RSP],RCX             ;
+                mov     16[RSP],RDX             ;
                 fild    word ptr 16[RSP]        ;
-                fld     real ptr [RDX]          ;
+                fld     real ptr [RCX]          ;
                 fscale                          ;
                 fstp    ST(1)                   ;
                 ret                             ;


### PR DESCRIPTION
I've grepped the code base for "naked" and then adapted inline assembly accessing function arguments in reversed order; i.e., by checking all naked non-vararg extern(D) functions with > 1 total parameters (incl. implicit ones like this and/or sret).
There may still be other non-naked assembly parts to be adapted.
