### PR TITLE
Fix std.base64 unit tests.

### DIFF
--- a/std/base64.d
+++ b/std/base64.d
@@ -637,7 +637,8 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
                 break;
             }
 
-            ++pos %= 4;
+            ++pos;
+            pos %= 4;
         }
 
 
@@ -1316,7 +1317,8 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
                 break;
             }
 
-            ++pos %= 3;
+            ++pos;
+            pos %= 3;
         }
 
 


### PR DESCRIPTION
`++pos %= 4;` yields:
`Error: expression this.pos += 1 does not mask any l-value`
