### PR TITLE
Unwanted static assert in socket.d from merge

### DIFF
--- a/std/socket.d
+++ b/std/socket.d
@@ -86,16 +86,6 @@ else version(Posix)
             TCP_KEEPINTVL = 5
         }
     }
-    else version(Solaris)
-    {
-        import core.sys.posix.sys.socket;
-        import core.sys.posix.sys.select;
-        private enum SD_RECEIVE = SHUT_RD;
-        private enum SD_SEND    = SHUT_WR;
-        private enum SD_BOTH    = SHUT_RDWR;
-    }
-    else
-        static assert(false);
 
     import core.sys.posix.netdb;
     import core.sys.posix.sys.un : sockaddr_un;


### PR DESCRIPTION
I think a merge accidently put back in a change that isn't needed for
Solaris and causes other platforms to not compile because a static
assert is hit.

Merge commit 713941d6e0cd83d8b80ac6535ceee830474d2dd9
See also commit 093d636de492625a6d686296d3cc6406671da9ff
