### PR TITLE
Fix unittest 64-bit real path

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -2851,7 +2851,7 @@ unittest
 //Tests for the double implementation
 unittest
 {
-    import core.stdc.stdlib, std.math;
+    import core.stdc.stdlib, std.math, std.exception;
     static if(real.mant_dig == 53)
     {
         //Should be parsed exactly: 53 bit mantissa

--- a/std/math.d
+++ b/std/math.d
@@ -5479,7 +5479,7 @@ real NaN(ulong payload) @trusted pure nothrow @nogc
     }
 }
 
-@safe pure nothrow @nogc unittest
+pure nothrow @nogc unittest
 {
     static if (floatTraits!(real).realFormat == RealFormat.ieeeDouble)
     {


### PR DESCRIPTION
This fixes a couple unittest compile errors when using a 64-bit real.  The change needs to go upstream too.  I'll do a pull for that later.

Would be nice if phobos developers had a way to test code paths for other than 80-bit real.
