### PR TITLE
Fix an std.math.poly() unit test.

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -6759,7 +6759,7 @@ body
     double x = 3.1;
     static real[] pp = [56.1, 32.7, 6];
 
-    assert(poly(x, pp) == (56.1L + (32.7L + 6L * x) * x));
+    assert(poly(x, pp) == (56.1L + (32.7L + 6.0L * x) * x));
 }
 
 @safe nothrow @nogc unittest


### PR DESCRIPTION
The expression `6L * x` with 6 being a `long` literal (instead of an intended `real` literal) and `x` of type `double` evaluates to a `double`.
`poly!real()` gets a `6.0L` in the array and an `x` promoted to a `real` and so obviously uses `real` precision.
On Linux x64, this results in a negligible difference.

Should probably go upstream too.
