### PR TITLE
Disable std.math ieeeFlags unittest - Issue #888

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -4314,6 +4314,14 @@ public:
 }
 
 ///
+version (LDC)
+{
+    unittest
+    {
+        pragma(msg, "ieeeFlags test disabled, see LDC Issue #888");
+    }
+}
+else
 unittest
 {
     static void func() {


### PR DESCRIPTION
A new unittest was added in 2.067 which may fail because the optimizer
can rearrange floating-point operations and tests of the floating-point
status flags (ieeeFlags).  See ldc-developers/ldc#888.

Disable this unittest until a solution is found so that rest of std.math unittests may run.
