### PR TITLE
Fix compilation.

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -2595,7 +2595,6 @@ int ilogb(real x)  @trusted nothrow @nogc
         int res;
         asm pure nothrow @nogc
         {
-            naked                       ;
             fld     real ptr [x]        ;
             fxam                        ;
             fstsw   AX                  ;


### PR DESCRIPTION
The errors were:
- phobos/std/math.d(2599): Error: only global variables can be referenced by identifier in naked asm
- phobos/std/math.d(2611): Error: only global variables can be referenced by identifier in naked asm
- phobos/std/math.d(2612): Error: only global variables can be referenced by identifier in naked asm
