### PR TITLE
Fix ARM_SoftFloat again

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -3981,7 +3981,7 @@ private:
             }
             else version (ARM_SoftFloat)
             {
-                cont = 0;
+                return 0;
             }
             else version (ARM)
             {


### PR DESCRIPTION
A botched merge to create 3f79ba25aadf1375b19d4a95e8d8d77ad8e7e405 ended up breaking ARM_SoftFloat.  This makes right again.

P.S. I don't know how I did it :-(
