### PR TITLE
AArch64 ieeeFlag fixes

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -4597,7 +4597,7 @@ private:
             }
             else version (AArch64)
             {
-                return __asm!uint("mrs $0, FPSR; and $0, $0, #0x1F", "=r");
+                return __asm!uint("mrs $0, FPSR\n and $0, $0, #0x1F", "=r");
             }
             else version (ARM)
             {
@@ -4662,9 +4662,11 @@ private:
             }
             else version (AArch64)
             {
-                uint old = getIeeeFlags();
-                old &= ~0b11111; // http://infocenter.arm.com/help/topic/com.arm.doc.ddi0408i/Chdfifdc.html
-                __asm("msr FPSR, $0", "r", old);
+                // http://infocenter.arm.com/help/topic/com.arm.doc.ddi0502f/CIHHDCHB.html
+                cast(void)__asm!uint
+                    ("mrs $0, fpsr\n"        // use '\n' as ';' is a comment
+                     "and $0, $0, #~0x1f\n"
+                     "msr fpsr, $0", "=r");
             }
             else version (ARM_SoftFloat)
             {
@@ -5153,10 +5155,11 @@ private:
             }
             else version (AArch64)
             {
-                // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/aarch64/fpu/fclrexcpt.c
-                ControlState old = getControlState();
-                old &= ~0b11111;
-                __asm("msr FPCR, $0", "r", old);
+                // http://infocenter.arm.com/help/topic/com.arm.doc.ddi0502f/CIHHDCHB.html
+                cast(void)__asm!uint
+                    ("mrs $0, fpsr\n"        // use '\n' as ';' is a comment
+                     "and $0, $0, #~0x1f\n"
+                     "msr fpsr, $0", "=r");
             }
             else version (ARM_SoftFloat)
             {


### PR DESCRIPTION
A few little things for use of AArch64 floating-point VFP registers copied from my iOS fork.
- use newline to separate AArch64 inline assembler instructions since ';' is comment char. @redstar, this may not be true for all platforms, but ARM docs show ';' comment chars and for iOS I was losing all the instructions after the first ';'.  I hope '\n' is fine for all.
- resetIeeeFlags() only clears bits of interest [4:0].
- clearExceptions() hits correct register.

I don't know about `hasExceptionTraps()` so left as is.  Probably need a different method to detect but I haven't looked into it.
