### PR TITLE
Use inline assembler for sin(real) and cos(real) if available.

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -652,7 +652,10 @@ auto conj(Num)(Num y) @safe pure nothrow @nogc
 
 version(LDC)
 {
-    real   cos(real   x) @safe pure nothrow @nogc { return llvm_cos(x); }
+    version(InlineAsm_X86_Any_X87)
+        real   cos(real   x) @trusted pure nothrow @nogc { return __asm!real("fcos", "={st},{st}", x); }
+    else
+        real   cos(real   x) @safe pure nothrow @nogc { return llvm_cos(x); }
     ///ditto
     double cos(double x) @safe pure nothrow @nogc { return llvm_cos(x); }
     ///ditto
@@ -692,7 +695,10 @@ float cos(float x) @safe pure nothrow @nogc { return cos(cast(real)x); }
  */
 version(LDC)
 {
-    real   sin(real   x) @safe pure nothrow @nogc { return llvm_sin(x); }
+    version(InlineAsm_X86_Any_X87)
+        real   sin(real   x) @trusted pure nothrow @nogc { return __asm!real("fsin", "={st},{st}", x); }
+    else
+        real   sin(real   x) @safe pure nothrow @nogc { return llvm_sin(x); }
     ///ditto
     double sin(double x) @safe pure nothrow @nogc { return llvm_sin(x); }
     ///ditto


### PR DESCRIPTION
This fixes an assertion failure on FreeBSD.
