### PR TITLE
std.math: Do not use inline assembly for expi().

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -2377,7 +2377,7 @@ creal expi(real y) @trusted pure nothrow @nogc
   version(LDC)
   {
     // LDC-specific: don't swap x87 registers for result
-    version(InlineAsm_X86_Any_X87)
+    version(none) // Was InlineAsm_X86_Any_X87 but this causes assertion failures
     {
         return __asm!creal("fsincos", "={st},={st(1)},{st}", y);
     }


### PR DESCRIPTION
This fixes an assertion failure seen on FreeBSD, Solaris and Circle-CI.
