### PR TITLE
Solaris unittest: fix formatTest for T.nan

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -1789,7 +1789,15 @@ unittest
         formatTest( to!(    const T)(5.5), "5.5" );
         formatTest( to!(immutable T)(5.5), "5.5" );
 
-        formatTest( T.nan, "nan" );
+        version(Solaris)
+        {
+            // This is the default value for Solaris libc.
+            formatTest(T.nan, "NaN" );
+        }
+        else
+        {
+            formatTest( T.nan, "nan" );
+        }
     }
 }
 


### PR DESCRIPTION
Fix std.format unittest AssertError.
