### PR TITLE
Solaris: fix std.datetime:LocalTime.utcToTZ issue.

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -27897,9 +27897,9 @@ private:
             buf = gmtime(&unixTime);
             tm timeInfoGmt = *buf;
 
-            return  (timeInfo.tm_sec-timeInfoGmt.tm_sec) +
-                    convert!("minutes", "seconds")(timeInfo.tm_min-timeInfoGmt.tm_min) +
-                    convert!("hours", "seconds")(timeInfo.tm_hour-timeInfoGmt.tm_hour);
+            return  (timeInfo.tm_sec - timeInfoGmt.tm_sec) +
+                    convert!("minutes", "seconds")(timeInfo.tm_min - timeInfoGmt.tm_min) +
+                    convert!("hours", "seconds")(timeInfo.tm_hour - timeInfoGmt.tm_hour);
         }
     }
 }

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -27649,7 +27649,11 @@ public:
       +/
     override long utcToTZ(long stdTime) @trusted const nothrow
     {
-        version(Posix)
+        version(Solaris)
+        {
+            return stdTime + convert!("seconds", "hnsecs")(tm_gmtoff(stdTime));
+        }
+        else version(Posix)
         {
             time_t unixTime = stdTimeToUnixTime(stdTime);
             tm* timeInfo = localtime(&unixTime);
@@ -27877,6 +27881,26 @@ private:
         static shared bool guard;
         initOnce!guard({tzset(); return true;}());
         return instance;
+    }
+
+
+    // The Solaris version of struct tm has no tm_gmtoff field, so do it here
+    version(Solaris)
+    {
+        long tm_gmtoff(long stdTime) @trusted const nothrow
+        {
+            import core.stdc.time : localtime, gmtime, tm;
+
+            time_t unixTime = stdTimeToUnixTime(stdTime);
+            tm* buf = localtime(&unixTime);
+            tm timeInfo = *buf;
+            buf = gmtime(&unixTime);
+            tm timeInfoGmt = *buf;
+
+            return  (timeInfo.tm_sec-timeInfoGmt.tm_sec) +
+                    convert!("minutes", "seconds")(timeInfo.tm_min-timeInfoGmt.tm_min) +
+                    convert!("hours", "seconds")(timeInfo.tm_hour-timeInfoGmt.tm_hour);
+        }
     }
 }
 


### PR DESCRIPTION
Patch by @nykytenko, originally submitted at https://github.com/dlang/phobos/pull/5016.