### PR TITLE
Use an alias instead of a wrapper function for intrinsic fabs()

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -3753,11 +3753,7 @@ real cbrt(real x) @trusted nothrow @nogc
  */
 version(LDC)
 {
-    real   fabs(real   x) @safe pure nothrow @nogc { return llvm_fabs(x); }
-    ///ditto
-    double fabs(double x) @safe pure nothrow @nogc { return llvm_fabs(x); }
-    ///ditto
-    float  fabs(float  x) @safe pure nothrow @nogc { return llvm_fabs(x); }
+    alias fabs = llvm_fabs;
 }
 else
 {


### PR DESCRIPTION
Solves https://github.com/ldc-developers/ldc/issues/2182