### PR TITLE
Add DragonFlyBSD support

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -26531,6 +26531,7 @@ auto tz = TimeZone.getTimeZone("America/Los_Angeles");
         version(Posix)
         {
             version(FreeBSD)      enum utcZone = "Etc/UTC";
+	    else version(DragonFlyBSD)      enum utcZone = "Etc/UTC";
             else version(linux)   enum utcZone = "UTC";
             else version(OSX)     enum utcZone = "UTC";
             else static assert(0, "The location of the UTC timezone file on this Posix platform must be set.");

--- a/std/file.d
+++ b/std/file.d
@@ -1826,6 +1826,9 @@ version (OSX)
 else version (FreeBSD)
     private extern (C) int sysctl (const int* name, uint namelen, void* oldp,
         size_t* oldlenp, const void* newp, size_t newlen);
+else version (DragonFlyBSD)
+    private extern (C) int sysctl (const int* name, uint namelen, void* oldp,
+        size_t* oldlenp, const void* newp, size_t newlen);
 
 /**
  * Returns the full path of the current executable.
@@ -1875,6 +1878,27 @@ else version (FreeBSD)
         }
     }
     else version (FreeBSD)
+    {
+        enum
+        {
+            CTL_KERN = 1,
+            KERN_PROC = 14,
+            KERN_PROC_PATHNAME = 12
+        }
+
+        int[4] mib = [CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1];
+        size_t len;
+
+        auto result = sysctl(mib.ptr, mib.length, null, &len, null, 0); // get the length of the path
+        errnoEnforce(result == 0);
+
+        auto buffer = new char[len - 1];
+        result = sysctl(mib.ptr, mib.length, buffer.ptr, &len, null, 0);
+        errnoEnforce(result == 0);
+
+        return buffer.assumeUnique;
+    }
+    else version (DragonFlyBSD)
     {
         enum
         {

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -99,6 +99,10 @@ else version(FreeBSD)
 {
     version = useSysctlbyname;
 }
+else version(DragonFlyBSD)
+{
+    version = useSysctlbyname;
+}
 
 version(Windows)
 {
@@ -169,6 +173,10 @@ else version(useSysctlbyname)
             auto nameStr = "machdep.cpu.core_count\0".ptr;
         }
         else version(FreeBSD)
+        {
+            auto nameStr = "hw.ncpu\0".ptr;
+        }
+        else version(DragonFlyBSD)
         {
             auto nameStr = "hw.ncpu\0".ptr;
         }

--- a/std/socket.d
+++ b/std/socket.d
@@ -189,6 +189,14 @@ string formatSocketError(int err) @trusted
             else
                 return "Socket error " ~ to!string(err);
         }
+        else version (DragonFlyBSD)
+        {
+            auto errs = strerror_r(err, buf.ptr, buf.length);
+            if (errs == 0)
+                cs = buf.ptr;
+            else
+                return "Socket error " ~ to!string(err);
+        }
         else version (Solaris)
         {
             auto errs = strerror_r(err, buf.ptr, buf.length);

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -68,6 +68,12 @@ version (FreeBSD)
     version = HAS_GETDELIM;
 }
 
+version (DragonFlyBSD)
+{
+    version = GENERIC_IO;
+    version = HAS_GETDELIM;
+}
+
 version (Solaris)
 {
     version = GENERIC_IO;


### PR DESCRIPTION
Add preliminary DragonFlyBSD support to ltsmaster in order to bootstrap
dlang support. This is largely based on copy/pasting the conditional
compilation from FreeBSD, but changing the guard from FreeBSD to DragonFlyBSD
with minimal changes.