### PR TITLE
[ltsmaster] Add missing definition for Solaris.

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -26534,6 +26534,7 @@ auto tz = TimeZone.getTimeZone("America/Los_Angeles");
             else version(DragonFlyBSD) enum utcZone = "UTC";
             else version(linux)        enum utcZone = "UTC";
             else version(OSX)          enum utcZone = "UTC";
+            else version(Solaris)      enum utcZone = "UTC";
             else                       static assert(0, "The location of the UTC timezone file on this Posix platform must be set.");
 
             auto tzs = [testTZ("America/Los_Angeles", "PST", "PDT", dur!"hours"(-8), dur!"hours"(1)),


### PR DESCRIPTION
This fixes unittest of `std.datetime` on Solaris. Backport from master.