### PR TITLE
[AArch64] Backport math functions from master.

### DIFF
--- a/std/internal/math/gammafunction.d
+++ b/std/internal/math/gammafunction.d
@@ -243,7 +243,9 @@ real igammaTemmeLarge(real a, real x)
 
 public:
 /// The maximum value of x for which gamma(x) < real.infinity.
-static if (floatTraits!(real).realFormat == RealFormat.ieeeExtended)
+static if (floatTraits!(real).realFormat == RealFormat.ieeeQuadruple)
+    enum real MAXGAMMA = 1755.5483429L;
+else static if (floatTraits!(real).realFormat == RealFormat.ieeeExtended)
     enum real MAXGAMMA = 1755.5483429L;
 else static if (floatTraits!(real).realFormat == RealFormat.ieeeDouble)
     enum real MAXGAMMA = 171.6243769L;
@@ -553,7 +555,12 @@ unittest {
 
 
 private {
-static if (floatTraits!(real).realFormat == RealFormat.ieeeExtended) {
+static if (floatTraits!(real).realFormat == RealFormat.ieeeQuadruple)
+{
+    enum real MAXLOG = 0x1.62e42fefa39ef35793c7673007e6p+13;  // log(real.max)
+    enum real MINLOG = -0x1.6546282207802c89d24d65e96274p+13; // log(real.min_normal*real.epsilon) = log(smallest denormal)
+}
+else static if (floatTraits!(real).realFormat == RealFormat.ieeeExtended) {
     enum real MAXLOG = 0x1.62e42fefa39ef358p+13L;  // log(real.max)
     enum real MINLOG = -0x1.6436716d5406e6d8p+13L; // log(real.min_normal*real.epsilon) = log(smallest denormal)
 }


### PR DESCRIPTION
Add missing IEEE quadruple implementations in `std.math` and
`std.internal.math.gammafunction`.