### PR TITLE
[Trivial] Exclude 1 math test on DFly.

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -7119,6 +7119,7 @@ Unqual!(Largest!(F, G)) pow(F, G)(F x, G y) @nogc @trusted pure nothrow
     assert(isNaN(pow(-0.2, PI)));
     // boundary cases. Note that epsilon == 2^^-n for some n,
     // so 1/epsilon == 2^^n is always even.
+    version(DragonFlyBSD) {} else                // exclude next test on DragonFlyBSD
     assert(pow(-1.0L, 1/real.epsilon - 1.0L) == -1.0L);
     assert(pow(-1.0L, 1/real.epsilon) == 1.0L);
     assert(isNaN(pow(-1.0L, 1/real.epsilon-0.5L)));


### PR DESCRIPTION
Not 100% what is causing this check to fail / or what this test is trying to prove):
assert(pow(-1.0L, 1/real.epsilon - 1.0L) == -1.0L);

Running (In D + ldc):
```
printf("%f\n", pow(-1.0L, 1/real.epsilon));
printf("%f\n", pow(-1.0L, 1/real.epsilon - 1.0L));
```
gives:
```
0.000000
nan
```

However (C + gcc -lm):
```
printf("%f\n", pow(-1.0L, 1/FLT_EPSILON));
printf("%f\n", pow(-1.0L, 1/FLT_EPSILON - 1.0L));
```
gives:
```
1.000000
-1.000000
```
Which is the correct answer.

Excluding the test on dragonfly for now, until i figure out the cause.