### PR TITLE
[ASan] Handle the (invalid) return value of posix_memalign

### DIFF
--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -233,6 +233,15 @@ struct AlignedMallocator
         assert(a.isGoodDynamicAlignment);
         void* result;
         auto code = posix_memalign(&result, a, bytes);
+
+version(OSX)
+version(LDC_AddressSanitizer)
+{
+        // The returnvalue with AddressSanitizer may be -1 (invalid)
+        // See https://bugs.llvm.org/show_bug.cgi?id=36510
+        if (code == -1)
+            return null;
+}
         if (code == ENOMEM)
             return null;
 

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -237,8 +237,8 @@ struct AlignedMallocator
 version(OSX)
 version(LDC_AddressSanitizer)
 {
-        // The returnvalue with AddressSanitizer may be -1 (invalid)
-        // See https://bugs.llvm.org/show_bug.cgi?id=36510
+        // The return value with AddressSanitizer may be -1 instead of ENOMEM
+        // or EINVAL. See https://bugs.llvm.org/show_bug.cgi?id=36510
         if (code == -1)
             return null;
 }


### PR DESCRIPTION
With ASan enabled, posix_memalign returns -1 upon invalid parameters or when not enough memory is available. This bug is reported with compiler-rt here: https://bugs.llvm.org/show_bug.cgi?id=36510

Still, if we deal with the invalid -1 return value in Phobos, we can continue testing with ASan enabled.
I'll keep an eye on the compiler-rt bug, and will remove the Phobos workaround when a fix lands in compiler-rt.

It looks like this workaround is only needed on OSX.

Test code:
```d
import std.stdio;

void main()
{
    import core.sys.posix.stdlib : posix_memalign;

    void* result;
    auto code = posix_memalign(&result, 1, 0);
    writeln(code);

    auto code2 = posix_memalign(&result, 32, size_t.max);
    writeln(code2);
}
```

Test with: `ASAN_OPTIONS=allocator_may_return_null=1  ldc2 -fsanitize=address -run memalign_testcase.d`