### PR TITLE
[ltsmaster] std.datetime should ignore leapseconds file.

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -28450,6 +28450,7 @@ assert(tz.dstName == "PDT");
 
                     if(!tzName.extension().empty ||
                        !tzName.startsWith(subName) ||
+                       tzName == "leapseconds" ||
                        tzName == "+VERSION")
                     {
                         continue;


### PR DESCRIPTION
Backport from master, see here: https://github.com/ldc-developers/phobos/blob/ldc/std/datetime/timezone.d#L2410