### PR TITLE
Backport logGamma dragonfly fix (from ltsmaster impl)

### DIFF
--- a/std/internal/math/gammafunction.d
+++ b/std/internal/math/gammafunction.d
@@ -566,14 +566,8 @@ real logGamma(real x)
             assert( feqrel(log(fabs(gamma(testpoints[i]))), testpoints[i+1]) > real.mant_dig-5);
         }
     }
-    version (DragonFlyBSD) { // FIXME: DragonFlyBSD: rounding differences between logGamma() and log() (ie:llvm_log())
-                             // Maybe we should be using lgamma or tgamma instead of gamma (ISO Standard N1570).
-        assert(feqrel(logGamma(-50.2),log(fabs(gamma(-50.2)))) > real.mant_dig-2);
-        assert(feqrel(logGamma(-0.008),log(fabs(gamma(-0.008)))) > real.mant_dig-2);
-    } else {
-        assert(logGamma(-50.2) == log(fabs(gamma(-50.2))));
-        assert(logGamma(-0.008) == log(fabs(gamma(-0.008))));
-    }    
+    assert(feqrel(logGamma(-50.2),log(fabs(gamma(-50.2)))) > real.mant_dig-2);
+    assert(feqrel(logGamma(-0.008),log(fabs(gamma(-0.008)))) > real.mant_dig-2);
     assert(feqrel(logGamma(-38.8),log(fabs(gamma(-38.8)))) > real.mant_dig-4);
     static if (real.mant_dig >= 64) // incl. 80-bit reals
         assert(feqrel(logGamma(1500.0L),log(gamma(1500.0L))) > real.mant_dig-2);

--- a/std/internal/math/gammafunction.d
+++ b/std/internal/math/gammafunction.d
@@ -566,8 +566,14 @@ real logGamma(real x)
             assert( feqrel(log(fabs(gamma(testpoints[i]))), testpoints[i+1]) > real.mant_dig-5);
         }
     }
-    assert(logGamma(-50.2) == log(fabs(gamma(-50.2))));
-    assert(logGamma(-0.008) == log(fabs(gamma(-0.008))));
+    version (DragonFlyBSD) { // FIXME: DragonFlyBSD: rounding differences between logGamma() and log() (ie:llvm_log())
+                             // Maybe we should be using lgamma or tgamma instead of gamma (ISO Standard N1570).
+        assert(feqrel(logGamma(-50.2),log(fabs(gamma(-50.2)))) > real.mant_dig-2);
+        assert(feqrel(logGamma(-0.008),log(fabs(gamma(-0.008)))) > real.mant_dig-2);
+    } else {
+        assert(logGamma(-50.2) == log(fabs(gamma(-50.2))));
+        assert(logGamma(-0.008) == log(fabs(gamma(-0.008))));
+    }    
     assert(feqrel(logGamma(-38.8),log(fabs(gamma(-38.8)))) > real.mant_dig-4);
     static if (real.mant_dig >= 64) // incl. 80-bit reals
         assert(feqrel(logGamma(1500.0L),log(gamma(1500.0L))) > real.mant_dig-2);


### PR DESCRIPTION
See [ltsmaster-phobos PR:45](https://github.com/ldc-developers/phobos/pull/45#discussion_r159118875)
(ie: using slightly less accuracy for DragonFlyBSD)

This somewhat ugly patch does work and i think it was ok for ltsmaster, having it in the master branch is not so nice. According to ISO Standard N1570 we should have been using 'lgamma/lgammal' and 'tgamma/tgammal' instead of gamma/gammal.

Question is this the right repo for this 'fix' or should this go upstream (dlang/phobos)?