### PR TITLE
AArch64: temporary patch to allow cross-compiling from non-AArch64

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -4316,6 +4316,13 @@ real hypot(real x, real y) @safe pure nothrow @nogc
 
     static assert(2*(SQRTMAX/2)*(SQRTMAX/2) <= real.max);
 
+    version(AArch64)
+    {
+        // This static assert overflows when cross-compiling from lower-precision
+        // floating-point to Quadruple.
+        pragma(msg, "hypot static assert disabled for AArch64 cross-compilation");
+    }
+    else
     // Proves that sqrt(real.max) ~~  0.5/sqrt(real.min_normal)
     static assert(real.min_normal*real.max > 2 && real.min_normal*real.max <= 4);
 


### PR DESCRIPTION
Temporarily disable so [the upcoming 1.11 release doesn't require patching](https://forum.dlang.org/post/bamkhgxhsmxilkaqlqji@forum.dlang.org), though I don't know that we'll ever bother getting 128-bit floating-point CTFE for AArch64 cross-compilation working. I'~ll~ve removed the `std.outbuffer` excision, since @kinke's `va_list` patch gets it to work ~once we get `va_list` working on AArch64~.

I'll also merge the `core.internal.convert` commit from dlang/druntime#2257 once I finish the pull and it's merged upstream or before the 1.11 release, whichever comes first, so that no patches will be needed to cross-compile the 1.11 stdlib and its tests for AArch64.