### PR TITLE
ASan fixes.

### DIFF
--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -1447,7 +1447,8 @@ public:
             size_t bitCount;
             foreach (i; 0 .. fullWords)
                 bitCount += countBitsSet(_ptr[i]);
-            bitCount += countBitsSet(_ptr[fullWords] & endMask);
+            if (endBits)
+                bitCount += countBitsSet(_ptr[fullWords] & endMask);
             return bitCount;
         }
         else

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -392,6 +392,7 @@ version (Posix)
     AlignedMallocator.instance.alignedReallocate(c, 32, 32);
     assert(c.ptr);
 
+    version (LDC_AddressSanitizer) {} else // AddressSanitizer does not support such large memory allocations (0x10000000000 max)
     version (DragonFlyBSD) {} else    /* FIXME: Malloc on DragonFly does not return NULL when allocating more than UINTPTR_MAX
                                        * $(LINK: https://bugs.dragonflybsd.org/issues/3114, dragonfly bug report)
                                        * $(LINK: https://github.com/dlang/druntime/pull/1999#discussion_r157536030, PR Discussion) */


### PR DESCRIPTION
Now unittests pass with ASan enabled (not yet with fakestack enabled, but that is probably because there is still a bug in druntime scanning of fakestack)

partly upstreamed: https://github.com/dlang/phobos/pull/8401