### PR TITLE
LDC: Fix PPC support to compile without deprecation warnings

### DIFF
--- a/std/math/hardware.d
+++ b/std/math/hardware.d
@@ -926,7 +926,7 @@ private:
             }
             else version (PPC_Any)
             {
-                asm pure nothrow @nogc @safe
+                asm pure nothrow @nogc @trusted
                 {
                     `mtfsb0 24
                      mtfsb0 25


### PR DESCRIPTION
Fixes the following:
std/math/hardware.d(929): Deprecation: `asm` statement cannot be marked `@safe`, use `@system` or `@trusted` instead